### PR TITLE
fix: adding class to body when nav is open

### DIFF
--- a/assets/scss/styles.css
+++ b/assets/scss/styles.css
@@ -27,6 +27,10 @@ body {
   margin: 0;
 }
 
+body.nav--open {
+  overflow: hidden;
+}
+
 html {
   box-sizing: border-box;
   color: #fff;

--- a/components/blocks/NavHeader.vue
+++ b/components/blocks/NavHeader.vue
@@ -35,6 +35,7 @@ export default{
       this.windowDiagonal = Math.sqrt(Math.pow(this.windowHeight, 2) + Math.pow(this.windowWidth, 2));
     },
     toggleNav() {
+      document.body.classList.toggle('nav--open');
       this.navOpen = !this.navOpen;
     }
   }


### PR DESCRIPTION
1. Adding class toggle to the body element in the toggleNav() method
2. Adding overflow:hidden to body width .nav--open class