### PR TITLE
Add longer site description in InfoAccordion

### DIFF
--- a/assets/json/accordionInfo.json
+++ b/assets/json/accordionInfo.json
@@ -1,6 +1,12 @@
 {
   "accordItems": [
     {
+      "heading": "What is this site?",
+      "content": [
+        "Leaderboards.gg is a site to host gaming leaderboards, with a focus on speedrunning. We're making a place that aims to listen more closely to gaming communities and allow them more control over the leaderboards they create."
+      ]
+    },
+    {
       "heading": "What are we going to use?? (Tech Stack)",
       "content": [
         "Frontend - nuxt.js, tailwind",

--- a/assets/json/accordionInfo.json
+++ b/assets/json/accordionInfo.json
@@ -3,7 +3,7 @@
     {
       "heading": "What is this site?",
       "content": [
-        "Leaderboards.gg is a site to host gaming leaderboards, with a focus on speedrunning. We're making a place that aims to listen more closely to gaming communities and allow them more control over the leaderboards they create."
+        "Leaderboards.gg is a site to host gaming leaderboards; for speedrunning, high scores, and more. We're making a place that aims to listen more closely to gaming communities and allow them more control over the leaderboards they create."
       ]
     },
     {


### PR DESCRIPTION
## What

Added a longer description of the site as a new top entry in the InfoAccordion.

In fact, we _may_ want to swap the places of InfoAccordion and MvpAccrordion. Feels like it's more fitting for an infosite.

## Link to Issue

N/A

## Acceptance

### Steps for testing

1. Make sure site doesn't break and looks like the screenshot below.

### Images

![image](https://user-images.githubusercontent.com/9867871/215789904-97e68da2-b1bb-49ab-8009-bfe36fb50ecf.png)
